### PR TITLE
fix: package.json & .snyk to reduce vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+version: v1.5.0
+ignore: {}
+patch:
+  'npm:uglify-js:20151024':
+    - jade > transformers > uglify-js:
+        patched: '2016-10-18T16:15:53.386Z'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "http-server www -p ${PORT:-3000}",
     "build": "jade view --obj data.json -o www; browserify -v -t babelify lib/index -o www/js/index.js; stylus -u nib -u griddy style/index.styl -o www/css/styles.css",
     "watch": "jade view --obj data.json  -o www -w | watchify -v -t babelify lib/index.js -o www/js/index.js | stylus -u nib -u griddy style/index.styl -w -o www/css/styles.css",
-    "dev": "livereload www | http-server www -p ${PORT:-3000} | npm run watch"
+    "dev": "livereload www | http-server www -p ${PORT:-3000} | npm run watch",
+    "snyk-protect": "snyk protect",
+    "prepublish": "npm run snyk-protect"
   },
   "author": "",
   "license": "ISC",
@@ -19,9 +21,11 @@
     "griddy": "^1.0.1",
     "http-server": "^0.9.0",
     "jade": "^1.11.0",
-    "livereload": "^0.4.1",
+    "livereload": "^0.6.0",
     "nib": "^1.1.0",
     "stylus": "^0.54.0",
-    "watchify": "^3.7.0"
-  }
+    "watchify": "^3.7.0",
+    "snyk": "^1.19.1"
+  },
+  "snyk": true
 }


### PR DESCRIPTION
There are some security fixes which Snyk automatically offers to resolve. Even if you do not want to add Snyk dependency, please upgrade the dependency livereload.

See also https://david-dm.org/RisingStack/nodeconf-budapest-2017 for reference.
